### PR TITLE
Update Post 'published' to 'published_at' in db seed file

### DIFF
--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -15,5 +15,5 @@ end
     title: Phil.words(5).capitalize,
     likes: rand(1..10),
     created_at: Date.today - rand(30).days,
-    published: true)
+    published_at: [(Date.today - rand(30).days), nil].sample)
 end


### PR DESCRIPTION
Currently the db/seed file is broken because Post.published is not a thing. So this PR fixes the seed file by changing that to published_at. 
