### PR TITLE
Add Elixir as channel option

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -16,6 +16,7 @@ $langs: (
   "clojure": "#db5855",
   "coffeescript": "#244776",
   "css": "#563d7c",
+  "elixir": "#701516",
   "go": "#375eab",
   "html": "#e44b23",
   "javascript": "#f1e05a",

--- a/app/views/ui/_post.html.haml
+++ b/app/views/ui/_post.html.haml
@@ -33,7 +33,7 @@
           more by
           %b= Phil.name
       - Phil.loop 1..4 do
-        - lang = %w(assembly bash clojure coffeescript css go html javascript ruby vim).sample
+        - lang = %w(assembly bash clojure coffeescript css elixir go html javascript ruby vim).sample
         %li
           %b= link_to "##{lang}", "#", class: lang
       %li

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,5 @@
 channels = %w(vim development design consulting rails ruby testing bash git
-              html/css javascript clojure sql mobile devops go internet)
+              html/css javascript clojure sql mobile devops go internet elixir)
 
 channels.each do |channel|
   puts "Finding or creating channel: #{channel}"


### PR DESCRIPTION
With @rondale-sc , @mrmicahcooper , @chadbrading , @mwoods79 and other Hashrocket employees playing with Elixir/Phoenix It would be nice to add that as an option to Channels. 

@camerond please update the color appropriately. 

Note that this PR doesn't actually ever run

``` ruby
Channel.create(name: "elixir")
```

Does hr-til write a migration to add new channels? Or do you just do it from the command line on production?
