### PR TITLE
Decouple specs from the app config, and remove hard-coded hashrocket options

### DIFF
--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -1,6 +1,6 @@
 class Developer < ActiveRecord::Base
   has_many :posts
-  validates :email, presence: true, format: { with: /\A.+@(#{ENV['permitted_domains']})\z/ }
+  validates :email, presence: true, format: { with: Proc.new { /\A.+@(#{ENV['permitted_domains']})\z/ } }
   validates :username, presence: true, uniqueness: true
   validates :twitter_handle, length: { maximum: 15 }, format: { with: /\A(?=.*[a-z])[a-z_\d]+\Z/i }, allow_blank: true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.action_controller.default_url_options = {
-    host: 'til.hashrocket.com',
+    host: ENV['host'],
     protocol: 'https://'
   }
 end

--- a/features/developer_visits_profile_page.feature
+++ b/features/developer_visits_profile_page.feature
@@ -1,11 +1,11 @@
 Feature: Developer visits profile page
 
   Scenario: Adds a twitter handle
-    Given I am a signed in developer with email "foo@hashrocket.com"
+    Given I am a signed in developer with email "foo@example.com"
     When I visit the homepage
     And I click profile
     Then I see my profile page
-    And I see my email "foo@hashrocket.com"
+    And I see my email "foo@example.com"
     When I enter my twitter handle
     And I click the "Submit" button
     Then I see the homepage

--- a/features/step_definitions/developer_steps.rb
+++ b/features/step_definitions/developer_steps.rb
@@ -3,7 +3,7 @@ Given 'I am not already a developer' do
 end
 
 Given 'I am already a developer' do
-  @developer = FactoryGirl.create(:developer, email: 'johnsmith@hashrocket.com', username: 'johnsmith')
+  @developer = FactoryGirl.create(:developer, email: 'johnsmith@example.com', username: 'johnsmith')
 end
 
 Given 'I am a signed in developer' do
@@ -21,7 +21,7 @@ Given(/^I am a signed in developer with email "([^"]*)"$/) do |email|
 end
 
 And 'I try to sign up or sign in with valid credentials' do
-  OmniAuth.config.add_mock(:google_oauth2, info: { name: 'John Smith', email: 'johnsmith@hashrocket.com' })
+  OmniAuth.config.add_mock(:google_oauth2, info: { name: 'John Smith', email: 'johnsmith@example.com' })
   visit google_oauth2_path
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -2,6 +2,8 @@ require 'simplecov'
 require 'cucumber/rails'
 require 'webmock/cucumber'
 
+ENV['permitted_domains'] = 'example.com'
+
 WebMock.disable_net_connect!(allow_localhost: true)
 
 OmniAuth.config.test_mode = true

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -3,10 +3,10 @@ describe SessionsController do
   describe '#create' do
     context 'with oauth' do
       it 'signs in existing developer by email' do
-        developer = FactoryGirl.create :developer, email: 'jake@hashrocket.com'
+        developer = FactoryGirl.create :developer, email: 'jake@example.com'
         request.env['omniauth.auth'] = {
           'info' => {
-            'email' => 'jake@hashrocket.com'
+            'email' => 'jake@example.com'
           }
         }
 
@@ -20,7 +20,7 @@ describe SessionsController do
       it 'signs up a new developer by email' do
         request.env['omniauth.auth'] = {
           'info' => {
-            'email' => 'newdev@hashrocket.com',
+            'email' => 'newdev@example.com',
             'name'  => 'John Smith'
           }
         }

--- a/spec/factories/developer.rb
+++ b/spec/factories/developer.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :developer do
     sequence :email do |n|
-      "developer#{n}@hashrocket.com"
+      "developer#{n}@example.com"
     end
 
     sequence :username do |n|

--- a/spec/helpers/post_helper_spec.rb
+++ b/spec/helpers/post_helper_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe PostHelper do
   describe '#tweet_link' do
     it 'returns a link to twitter' do
-      stub_const('ENV', { 'default_twitter_handle' => 'twitter_handle' })
+      stub_const('ENV', ENV.merge('default_twitter_handle' => 'twitter_handle'))
 
       @post = FactoryGirl.create(:post)
       @post.slug = '1234'

--- a/spec/helpers/post_helper_spec.rb
+++ b/spec/helpers/post_helper_spec.rb
@@ -3,11 +3,13 @@ require 'rails_helper'
 describe PostHelper do
   describe '#tweet_link' do
     it 'returns a link to twitter' do
+      stub_const('ENV', { 'default_twitter_handle' => 'twitter_handle' })
+
       @post = FactoryGirl.create(:post)
       @post.slug = '1234'
       @post.save!
 
-      expected_result = "<a href=\"http://twitter.com/share\" class=\"twitter-share-button\" data-text=\"Today I learned: Web Development\" data-via=\"hashrocket\" data-hashtags=\"phantomjs\" data-url=\"http://www.example.com/posts/1234-web-development\">Tweet</a>"
+      expected_result = "<a href=\"http://twitter.com/share\" class=\"twitter-share-button\" data-text=\"Today I learned: Web Development\" data-via=\"twitter_handle\" data-hashtags=\"phantomjs\" data-url=\"http://www.example.com/posts/1234-web-development\">Tweet</a>"
 
       expect(helper.tweet_link(@post)).to eq expected_result
     end

--- a/spec/models/developer_spec.rb
+++ b/spec/models/developer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Developer do
-  let(:developer) { FactoryGirl.create(:developer) }
+  let(:developer) { FactoryGirl.build(:developer) }
 
   it 'should have a valid factory' do
     expect(developer).to be_valid
@@ -19,12 +19,9 @@ describe Developer do
 
   context 'validates email domains' do
     before do
-      @prev_permitted_domains = ENV['permitted_domains']
-      ENV['permitted_domains'] = 'hashrocket.com|hshrcket.com'
-    end
-
-    after do
-      ENV['permitted_domains'] = @prev_permitted_domains
+      stub_const('ENV', {
+        'permitted_domains' => 'hashrocket.com|hshrckt.com'
+      })
     end
 
     it 'and allows whitelisted domains' do
@@ -42,6 +39,7 @@ describe Developer do
   end
 
   it 'should validate username uniqueness' do
+    FactoryGirl.create(:developer, username: developer.username)
     dup_developer = FactoryGirl.build(:developer, username: developer.username)
     expect(dup_developer).to_not be_valid
     expect(dup_developer.errors.messages[:username]).to eq ['has already been taken']

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,4 +14,10 @@ RSpec.configure do |config|
   end
 
   config.default_formatter = 'doc' if config.files_to_run.one?
+
+  config.before(:each) do
+    stub_const('ENV', {
+      'permitted_domains' => 'example.com'
+    })
+  end
 end


### PR DESCRIPTION
Hey guys,

There are a couple of sets of changes in this pull request.

1. Specs are now decoupled from the application configuration (application.yml).  Before this change, changing permitted_domains or default_twitter_handle killed the specs.

1. The production config has also been updated to get the default_url_options host from the application config.

Cheers!