### PR TITLE
Only post to slack on a likes threshold event once

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -13,7 +13,6 @@ class Post < ActiveRecord::Base
   belongs_to :channel
 
   before_create :generate_slug
-  after_update :notify_slack_on_likes_threshold, if: :likes_threshold?
   after_save :notify_slack_on_publication, if: :publishing?
 
   scope :published, -> { where('published_at is not null') }
@@ -42,6 +41,8 @@ class Post < ActiveRecord::Base
 
   def increment_likes
     self.likes += 1
+    self.max_likes += 1
+    notify_slack_on_likes_threshold if likes_threshold?
     save
   end
 
@@ -74,15 +75,11 @@ class Post < ActiveRecord::Base
   private
 
   def likes_threshold?
-    tens_of_likes? && likes_changed?
+    max_likes % 10 == 0
   end
 
   def publishing?
     published_at? && published_at_changed?
-  end
-
-  def tens_of_likes?
-    !likes.zero? && likes % 10 == 0
   end
 
   def word_count

--- a/db/migrate/20160211043316_add_max_likes.rb
+++ b/db/migrate/20160211043316_add_max_likes.rb
@@ -1,0 +1,14 @@
+class AddMaxLikes < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      alter table posts add column max_likes integer not null default 1;
+      update posts set max_likes = likes;
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      alter table posts drop column max_likes;
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160205153837) do
+ActiveRecord::Schema.define(version: 20160211043316) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,6 +58,7 @@ ActiveRecord::Schema.define(version: 20160205153837) do
     t.integer  "likes",        default: 1,     null: false
     t.boolean  "tweeted",      default: false, null: false
     t.datetime "published_at"
+    t.integer  "max_likes",    default: 1,     null: false
   end
 
   add_index "posts", ["channel_id"], name: "index_posts_on_channel_id", using: :btree

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -168,16 +168,13 @@ describe Post do
     end
   end
 
-  it 'knows if its likes count is a factor of ten, ignoring zeroes' do
-    method = :tens_of_likes?
+  it 'knows if its max likes count is a factor of ten' do
+    method = :likes_threshold?
 
-    post.likes = 10
+    post.max_likes = 10
     expect(post.send(method)).to eq true
 
-    post.likes = 11
-    expect(post.send(method)).to eq false
-
-    post.likes = 0
+    post.max_likes = 11
     expect(post.send(method)).to eq false
   end
 
@@ -231,6 +228,21 @@ describe Post do
 
         expect(post).to receive(:notify_slack)
         post.save
+      end
+    end
+  end
+
+  context 'slack integration on tens of likes' do
+    describe 'reaches the milestone more than once' do
+      it 'should notify slack only once' do
+        post = FactoryGirl.create(:post, likes: 9, max_likes: 9)
+
+        expect(post).to receive(:notify_slack).once
+        post.increment_likes # 10
+        post.increment_likes # 11
+        post.decrement_likes # 10
+        post.decrement_likes # 9
+        post.increment_likes # 10
       end
     end
   end


### PR DESCRIPTION
Closes Issue #20

This change adds `max_likes` to each post that corresponds with the amount of times a post's likes count has been incremented. Once a post's max likes has hit a (divisible by ten) threshold, Slack is notified; and it won't happen again if that post's likes count ever hits that milestone twice.

This is to cut down on noise in Slack when a person clicks 'Like' on a post, then immediately clicks 'Unlike', something that has been happening more and more as traffic increases on the site.