### PR TITLE
Strip dashes from Twitter handles

### DIFF
--- a/app/helpers/post_helper.rb
+++ b/app/helpers/post_helper.rb
@@ -24,11 +24,18 @@ module PostHelper
   def tweet_link(post)
     title = post.title
     handle = post.twitter_handle
-    channel = post.channel_name
+    channel = post.channel_name.delete('-')
+
     url = Rails.configuration.server_url + post_path(post)
 
-    content_tag(:a, 'Tweet', href: 'http://twitter.com/share', class: 'twitter-share-button',
-                             'data-text': "Today I learned: #{title}", 'data-via': "#{handle}",
-                             'data-hashtags': "#{channel}", 'data-url': "#{url}")
+    content_tag(:a,
+      'Tweet',
+      href: 'http://twitter.com/share',
+      class: 'twitter-share-button',
+      'data-text': "Today I learned: #{title}",
+      'data-via': "#{handle}",
+      'data-hashtags': "#{channel}",
+      'data-url': "#{url}"
+    )
   end
 end

--- a/spec/helpers/post_helper_spec.rb
+++ b/spec/helpers/post_helper_spec.rb
@@ -24,5 +24,19 @@ describe PostHelper do
 
       expect(helper.tweet_link(@post)).to eq expected_result
     end
+
+    context "with dashed channel name" do
+      it "returns a link to twitter with a non-dashed hashtag" do
+        developer = FactoryGirl.create(:developer, twitter_handle: 'awesomehandle')
+        channel = FactoryGirl.create(:channel, name: 'dashy-channel')
+        @post = FactoryGirl.create(:post, developer: developer, channel: channel)
+        @post.slug = '1234'
+        @post.save!
+
+        expected_result = "<a href=\"http://twitter.com/share\" class=\"twitter-share-button\" data-text=\"Today I learned: Web Development\" data-via=\"awesomehandle\" data-hashtags=\"dashychannel\" data-url=\"http://www.example.com/posts/1234-web-development\">Tweet</a>"
+
+        expect(helper.tweet_link(@post)).to eq expected_result
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes issue #34

Twitter does not allow dashed ('-') hashtags and breaks the searchable
hashtag link on any dash. This change formats the hashtags by removing
dashes, so every hashtag is searchable on Twitter.