### PR TITLE
Escape html characters for slack

### DIFF
--- a/app/serializers/post_slack/create_serializer.rb
+++ b/app/serializers/post_slack/create_serializer.rb
@@ -6,6 +6,16 @@ class PostSlack::CreateSerializer < ActiveModel::Serializer
 
   def text
     "#{object.developer_slack_display_name} created a new post "\
-    "- <#{Rails.configuration.server_url}#{post_path(object)}|#{object.title}> ##{object.channel_name}"
+    "- <#{full_url}|#{encoded_title}> ##{object.channel_name}"
+  end
+
+  private
+
+  def encoded_title
+    CGI.escapeHTML(object.title)
+  end
+
+  def full_url
+    Rails.configuration.server_url + post_path(object)
   end
 end

--- a/spec/serializers/post_slack/create_serializer_spec.rb
+++ b/spec/serializers/post_slack/create_serializer_spec.rb
@@ -39,5 +39,24 @@ RSpec.describe PostSlack::CreateSerializer, type: :serializer do
 
       expect(serialized).to eql(expected_text)
     end
+
+    it 'encodes 3 special Slack characters as HTML entities' do
+      developer = FactoryGirl.build(:developer, username: 'tpope', slack_name: 'Tim Pope')
+      post = FactoryGirl.build(:post,
+                        slug: '38fe87b97c',
+                        body: 'learned some things',
+                        developer: developer,
+                        title: 'The `<picture>` & `<div>` elements are here to stay!',
+                        channel: FactoryGirl.create(:channel, name: 'hacking')
+                       )
+
+      serializer = PostSlack::CreateSerializer.new(post)
+      serialized = JSON.parse(serializer.to_json)['text']
+
+      expected_text = 'Tim Pope created a new post - <http://www.example.com/'\
+      'posts/38fe87b97c-the-picture-div-elements-are-here-to-stay|The `&lt;picture&gt;` &amp; `&lt;div&gt;` elements are here to stay!> #hacking'
+
+      expect(serialized).to eql(expected_text)
+    end
   end
 end


### PR DESCRIPTION
  Slack requires 3 characters in messages to be esacped. TIL
  only needs to worry about post titles.

  https://api.slack.com/docs/formatting#how_to_escape_characters