### PR TITLE
Encode slack messages on likes threshold event

### DIFF
--- a/app/serializers/post_slack/likes_threshold_serializer.rb
+++ b/app/serializers/post_slack/likes_threshold_serializer.rb
@@ -8,10 +8,18 @@ class PostSlack::LikesThresholdSerializer < ActiveModel::Serializer
     likes = object.likes
 
     "#{object.developer_slack_display_name}'s post has #{likes} likes! "\
-    "#{emojis[likes_index(likes)].to_sym || '😀'} - <#{Rails.configuration.server_url}#{post_path(object)}|#{object.title}>"
+    "#{emojis[likes_index(likes)].to_sym || '😀'} - <#{full_url}|#{encoded_title}>"
   end
 
   private
+
+  def encoded_title
+    CGI.escapeHTML(object.title)
+  end
+
+  def full_url
+    Rails.configuration.server_url + post_path(object)
+  end
 
   def likes_index(likes)
     (likes / 10) - 1

--- a/spec/serializers/post_slack/likes_threshold_serializer_spec.rb
+++ b/spec/serializers/post_slack/likes_threshold_serializer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe PostSlack::LikesThresholdSerializer, type: :serializer do
-  context 'Individual Resource Representation' do
+  context 'a generic example' do
     it 'is serialized correctly' do
       developer = FactoryGirl.build(:developer,
                                     username: 'tpope')
@@ -21,8 +21,10 @@ RSpec.describe PostSlack::LikesThresholdSerializer, type: :serializer do
 
       expect(serialized).to eq result
     end
+  end
 
-    it 'is serialized correctly and includes Slack display name' do
+  context 'with a Slack display name' do
+    it 'is serialized with the Slack display name' do
       developer = FactoryGirl.build(:developer, username: 'tpope', slack_name: 'Tim Pope')
       post = FactoryGirl.build(:post,
                         slug: 'sluggishslug',
@@ -39,6 +41,28 @@ RSpec.describe PostSlack::LikesThresholdSerializer, type: :serializer do
       "posts/sluggishslug-entitled-title|entitled title>"
 
       expect(serialized).to eq result
+    end
+  end
+
+  context 'with characters that must be escaped in Slack' do
+    it 'is serialized with special Slack characters encoded as HTML entities' do
+      developer = FactoryGirl.build(:developer, username: 'tpope')
+      post = FactoryGirl.build(:post,
+                        slug: 'sluggishslug',
+                        body: 'learned some things',
+                        developer: developer,
+                        title: 'The `<picture>` & `<div>` elements are here to stay!',
+                        likes: 10
+                       )
+
+      serializer = PostSlack::LikesThresholdSerializer.new(post)
+      serialized = JSON.parse(serializer.to_json)['text']
+
+      expected_text = "tpope's post has 10 likes! 🎉 - <http://www.example.com/"\
+      "posts/sluggishslug-the-picture-div-elements-are-here-to-stay|The `&lt;picture&gt;` "\
+      "&amp; `&lt;div&gt;` elements are here to stay!>"
+
+      expect(serialized).to eql(expected_text)
     end
   end
 end


### PR DESCRIPTION
This changes the message sent to Slack when posts hit a likes threshold, escaping characters uniquely required for that platform.