### PR TITLE
Guest Posts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* Add guest post feature.
+
+  *Jake Worth*
+
 * Remove n + 1 from statistics page.
 
   *Dillon Hafer*

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 > TIL is an open-source project by the team at
 > [Hashrocket](https://hashrocket.com/) that catalogues the sharing &
 > accumulation of knowledge as it happens day-to-day. Posts have a 200-word
-> limit and any Hashrocket team member can contribute. We hope you enjoy
-> learning along with us.
+> limit, and posting is open to any Rocketeer as well as select friends of the
+> team. We hope you enjoy learning along with us.
 
 This site was open sourced as a window into our development process, as well as
 to allow people to experiment with the site on their own and contribute to the
@@ -26,16 +26,19 @@ $ rake db:setup
 $ rails s
 ```
 
-Authentication is managed by Omniauth and Google. To whitelist a domain or multiple domains, add the domain name to your environmental variables:
+Authentication is managed by Omniauth and Google. To whitelist a domain,
+multiple domains, or a specific email, add those configurations to your
+environmental variables:
 
 ```yml
 # config/application.yml
 
 permitted_domains: 'hashrocket.com|hshrckt.com'
+permitted_emails: 'friend@whitelist.com'
 ```
 
-With this in place, you can visit '/admin' and log in with an email address from
-the domain you've allowed.
+With this in place, you can visit '/admin' and log in with an email address or
+domain you've allowed.
 
 ### Dependencies
 

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -1,6 +1,6 @@
 class Developer < ActiveRecord::Base
   has_many :posts
-  validates :email, presence: true, format: { with: Proc.new { /\A.+@(#{ENV['permitted_domains']})\z/ } }
+  validates :email, presence: true, format: { with: Proc.new { /\A(.+@(#{ENV['permitted_domains']})|(#{ENV['permitted_emails']}))\z/ } }
   validates :username, presence: true, uniqueness: true
   validates :twitter_handle, length: { maximum: 15 }, format: { with: /\A(?=.*[a-z])[a-z_\d]+\Z/i }, allow_blank: true
 

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -6,6 +6,7 @@ development: &default
   host: 'www.example.com'
   protocol: 'http://'
   permitted_domains: 'hashrocket.com|hshrckt.com|example.com'
+  permitted_emails: 'johnsmith@whitelisted-guest.com'
   slack_post_endpoint:
   twitter_access_token:
   twitter_access_token_secret:

--- a/features/developer_signs_up_or_signs_in.feature
+++ b/features/developer_signs_up_or_signs_in.feature
@@ -9,3 +9,8 @@ Feature: Developer signs up or signs in
     Given I am already a developer
     And I try to sign up or sign in with valid credentials
     Then I am signed in
+
+  Scenario: Guest signs in
+    Given I try to sign up with a white-listed guest email address
+    Then I am signed in
+    And a guest user is created

--- a/features/step_definitions/developer_steps.rb
+++ b/features/step_definitions/developer_steps.rb
@@ -85,3 +85,14 @@ When 'I click edit' do
     click_on 'edit'
   end
 end
+
+Given 'I try to sign up with a white-listed guest email address' do
+  OmniAuth.config.add_mock(:google_oauth2, info: { name: 'John Smith', email: 'johnsmith@whitelisted-guest.com' })
+  visit google_oauth2_path
+end
+
+And 'a guest user is created' do
+  expect(@developer).to be
+  expect(@developer.email).to eq 'johnsmith@whitelisted-guest.com'
+  expect(@developer.username).to eq 'johnsmith'
+end

--- a/spec/models/developer_spec.rb
+++ b/spec/models/developer_spec.rb
@@ -18,10 +18,9 @@ describe Developer do
   end
 
   context 'validates email domains' do
-    before do
-      stub_const('ENV', {
-        'permitted_domains' => 'hashrocket.com|hshrckt.com'
-      })
+    it 'and allows whitelisted email addresses' do
+      developer.email = 'johnsmith@whitelisted-guest.com'
+      expect(developer).to be_valid
     end
 
     it 'and allows whitelisted domains' do
@@ -32,7 +31,7 @@ describe Developer do
     end
 
     it 'should deny an email from a non-whitelisted domain' do
-      developer.email = 'foo@example.com'
+      developer.email = 'foo@haxor.net'
       expect(developer).to_not be_valid
       expect(developer.errors.messages[:email]).to eq ['is invalid']
     end


### PR DESCRIPTION
This feature allows guest posters, indicated by white-listed email addresses found in the environmental variables, to log in and create posts.