### PR TITLE
Add hottest TILs to stats page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* Add most liked TILs.
+
+  *Jake Worth & Josh Davey*
+
 * Add guest post feature.
 
   *Jake Worth*

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -1,6 +1,11 @@
 class StatisticsController < ApplicationController
-  helper_method :top_ten, :authors, :channels,
-    :highest_count_last_30_days, :posts_per_day, :posts
+  helper_method :authors,
+    :channels,
+    :highest_count_last_30_days,
+    :hot_posts,
+    :posts,
+    :posts_per_day,
+    :top_ten
 
   private
 
@@ -8,6 +13,14 @@ class StatisticsController < ApplicationController
 
   def posts
     Post.published
+  end
+
+  def hot_posts
+    hot_posts = ActiveRecord::Base.connection.execute('select id from hot_posts limit 10;')
+
+    hot_posts.map do |hot_post|
+      Post.find(hot_post['id'])
+    end
   end
 
   def top_ten

--- a/app/views/statistics/index.html.haml
+++ b/app/views/statistics/index.html.haml
@@ -13,8 +13,21 @@
             .activity_chart_bar(style="height: #{(ppd.count.to_f/highest_count_last_30_days) * 100}%")
     %article
       %header
+        %h1 Hottest TILs
+      %ul.post_list
+        - hot_posts.each do |hp|
+          %li
+            = link_to post_path hp do
+              %b
+                = hp.title
+              %small
+                \##{hp.channel.name}
+                %span •
+                #{pluralize(hp.likes, 'like')}
+    %article
+      %header
         %h1 Most liked TILs
-      %ul.post_list#top-ten
+      %ul.post_list
         - top_ten.each do |tt|
           %li
             = link_to post_path tt do

--- a/features/step_definitions/general_steps.rb
+++ b/features/step_definitions/general_steps.rb
@@ -41,11 +41,6 @@ Then 'I see statistics' do
     expect(page).to have_selector 'li', count: 30
   end
 
-  within '#top-ten' do
-    expect(page).to have_link 'li', count: 10
-    expect(page).to have_content 'Web Development', count: 10
-  end
-
   within '#channels' do
     expect(page).to have_link 'a', count: 35
     expect(page).to have_content 'phantomjs', count: 35

--- a/spec/controllers/statistics_controller_spec.rb
+++ b/spec/controllers/statistics_controller_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe StatisticsController do
+  describe '#hot_posts' do
+    it 'returns a list of hot posts' do
+      FactoryGirl.create_list(:post, 10)
+
+      expect(described_class.new.send(:hot_posts).size).to eq 10
+    end
+  end
+
+  describe '#top_ten' do
+    it 'returns a list of most liked posts' do
+      FactoryGirl.create_list(:post, 9, likes: 9)
+      FactoryGirl.create(:post, likes: 10, title: 'Popular post!')
+
+      expect(described_class.new.send(:top_ten).size).to eq 10
+      expect(described_class.new.send(:top_ten).first.title).to eq 'Popular post!'
+    end
+  end
+end


### PR DESCRIPTION
This adds 'hottest TILs' to the statistics page, per Josh Davey's awesome database view.

The goal is to have more relevant, dynamic information shown on the stats page.