### PR TITLE
Remove default channels in non-development modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,13 @@ $ git clone https://github.com/hashrocket/hr-til
 $ cd hr-til
 $ bundle install
 $ cp config/application.yml{.example,}
-$ rake db:setup
+$ rake db:create db:migrate db:seed
 $ rails s
 ```
+
+In development, `db:seed` will load seed data for channels, developers, and
+posts. Omit this command to opt-out of the seed step, or create your own seeds
+by altering `db/seeds/development.rb`.
 
 Authentication is managed by Omniauth and Google. To whitelist a domain,
 multiple domains, or a specific email, add those configurations to your

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,29 +1,3 @@
-channels = %w(
-  clojure
-  command-line
-  design
-  devops
-  elixir
-  emberjs
-  git
-  go
-  html-css
-  javascript
-  mobile
-  rails
-  react
-  ruby
-  sql
-  testing
-  vim
-  workflow
-)
-
-channels.each do |channel|
-  puts "Finding or creating channel: #{channel}"
-  Channel.find_or_create_by!(name: channel)
-end
-
 seed_file = Rails.root.join("db/seeds/#{Rails.env}.rb")
 if seed_file.exist? && !ENV['NO_SEED_DATA']
   puts "*** Loading #{Rails.env} seed data"

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -1,14 +1,42 @@
 # To download production data instead of these seeds, run
 # rake db:restore_production_dump
 
-5.times do |i|
-  puts "Creating developer ##{i + 1}"
+channels = %w(
+  clojure
+  command-line
+  design
+  devops
+  elixir
+  emberjs
+  git
+  go
+  html-css
+  javascript
+  mobile
+  rails
+  react
+  ruby
+  sql
+  testing
+  vim
+  workflow
+)
+
+print "Creating #{channels.length} channels"
+channels.each do |channel|
+  Channel.find_or_create_by!(name: channel)
+end
+puts " ...done."
+
+print "Creating developers"
+5.times do
   username = Phil.name.downcase.delete(' ')
   Developer.create!(username: username, email: "#{username}@hashrocket.com")
 end
+puts " ...done."
 
-40.times do |i|
-  puts "Creating post ##{i + 1}"
+print "Creating posts"
+40.times do
   channel = Channel.all.sample
   likes = rand(1..20)
 
@@ -21,3 +49,4 @@ end
     created_at: Date.today - rand(30).days,
     published_at: [(Date.today - rand(30).days), nil].sample)
 end
+puts " ...done."


### PR DESCRIPTION
Relates to issue #12

- This is part of this application's ongoing transition to an open-
source, broadly usable product. Storing these channel names in
`seeds.rb` forced all users to adopt Hashrocket's channels as
a default or change the code. Now, this only happens in development,
which is still valuable for quick setup, and documentation explains
how to opt-out.