### PR TITLE
Only escape three special symbols for Slack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* Narrow scope of Slack HTML escaping.
+
+  *Jake Worth*
+
 * Upgrade Rails.
 
   *Jake Worth*

--- a/app/serializers/post_slack/create_serializer.rb
+++ b/app/serializers/post_slack/create_serializer.rb
@@ -19,7 +19,9 @@ class PostSlack::CreateSerializer < ActiveModel::Serializer
   end
 
   def encoded_title
-    CGI.escapeHTML(object.title)
+    # Escape only three symbols:
+    # https://api.slack.com/docs/formatting#how_to_escape_characters
+    object.title.gsub('&', '&amp;').gsub('<', '&lt;').gsub('>','&gt;')
   end
 
   def full_url

--- a/app/serializers/post_slack/likes_threshold_serializer.rb
+++ b/app/serializers/post_slack/likes_threshold_serializer.rb
@@ -14,7 +14,9 @@ class PostSlack::LikesThresholdSerializer < ActiveModel::Serializer
   private
 
   def encoded_title
-    CGI.escapeHTML(object.title)
+    # Escape only three symbols:
+    # https://api.slack.com/docs/formatting#how_to_escape_characters
+    object.title.gsub('&', '&amp;').gsub('<', '&lt;').gsub('>','&gt;')
   end
 
   def full_url

--- a/spec/serializers/post_slack/create_serializer_spec.rb
+++ b/spec/serializers/post_slack/create_serializer_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe PostSlack::CreateSerializer, type: :serializer do
+
+  def serialize_post(post)
+    serializer = PostSlack::CreateSerializer.new(post)
+    JSON.parse(serializer.to_json)['text']
+  end
+
   context 'Serialized resource' do
     it 'is correct' do
       developer = FactoryGirl.build(:developer, username: 'tpope')
@@ -12,9 +18,7 @@ RSpec.describe PostSlack::CreateSerializer, type: :serializer do
                         channel: FactoryGirl.create(:channel, name: 'hacking')
                        )
 
-      serializer = PostSlack::CreateSerializer.new(post)
-      serialized = JSON.parse(serializer.to_json)['text']
-
+      serialized = serialize_post(post)
       expected_text = 'tpope created a new post - <http://www.example.com/'\
       'posts/sluggishslug-entitled-title|entitled title> #hacking'
 
@@ -31,9 +35,7 @@ RSpec.describe PostSlack::CreateSerializer, type: :serializer do
                         channel: FactoryGirl.create(:channel, name: 'hacking')
                        )
 
-      serializer = PostSlack::CreateSerializer.new(post)
-      serialized = JSON.parse(serializer.to_json)['text']
-
+      serialized = serialize_post(post)
       expected_text = 'Tim Pope created a new post - <http://www.example.com/'\
       'posts/sluggishslug-entitled-title|entitled title> #hacking'
 
@@ -50,9 +52,7 @@ RSpec.describe PostSlack::CreateSerializer, type: :serializer do
                         channel: FactoryGirl.create(:channel, name: 'hacking')
                        )
 
-      serializer = PostSlack::CreateSerializer.new(post)
-      serialized = JSON.parse(serializer.to_json)['text']
-
+      serialized = serialize_post(post)
       expected_text = 'Tim Pope created a new post - <http://www.example.com/'\
       'posts/38fe87b97c-the-picture-div-elements-are-here-to-stay|The `&lt;picture&gt;` &amp; `&lt;div&gt;` elements are here to stay!> #hacking'
 
@@ -71,9 +71,7 @@ RSpec.describe PostSlack::CreateSerializer, type: :serializer do
                         channel: FactoryGirl.create(:channel, name: 'hacking')
                        )
 
-      serializer = PostSlack::CreateSerializer.new(post)
-      serialized = JSON.parse(serializer.to_json)['text']
-
+      serialized = serialize_post(post)
       expected_text = 'This is the 100th post to Today I Learned! Tim Pope created a new post '\
       '- <http://www.example.com/posts/sluggishslug-entitled-title|entitled title> #hacking'
 
@@ -84,9 +82,7 @@ RSpec.describe PostSlack::CreateSerializer, type: :serializer do
       developer = FactoryGirl.build(:developer, username: 'tpope')
       post = FactoryGirl.create(:post, title: 'Let me prepare you a "quote"')
 
-      serializer = PostSlack::CreateSerializer.new(post)
-      serialized = JSON.parse(serializer.to_json)['text']
-
+      serialized = serialize_post(post)
       expected_text = 'Let me prepare you a "quote"'
 
       expect(serialized).to include(expected_text)

--- a/spec/serializers/post_slack/create_serializer_spec.rb
+++ b/spec/serializers/post_slack/create_serializer_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe PostSlack::CreateSerializer, type: :serializer do
-  context 'Individual Resource Representation' do
-    it 'is serialized correctly' do
+  context 'Serialized resource' do
+    it 'is correct' do
       developer = FactoryGirl.build(:developer, username: 'tpope')
       post = FactoryGirl.build(:post,
                         slug: 'sluggishslug',
@@ -21,7 +21,7 @@ RSpec.describe PostSlack::CreateSerializer, type: :serializer do
       expect(serialized).to eql(expected_text)
     end
 
-    it 'is serialized and includes Slack display name' do
+    it 'includes Slack display name' do
       developer = FactoryGirl.build(:developer, username: 'tpope', slack_name: 'Tim Pope')
       post = FactoryGirl.build(:post,
                         slug: 'sluggishslug',
@@ -59,7 +59,7 @@ RSpec.describe PostSlack::CreateSerializer, type: :serializer do
       expect(serialized).to eql(expected_text)
     end
 
-    it 'is serialized and includes milestone events' do
+    it 'includes milestone events' do
       developer = FactoryGirl.build(:developer, username: 'tpope', slack_name: 'Tim Pope')
       FactoryGirl.create(:post)
       FactoryGirl.create_list(:post, 99, published_at: Time.now)
@@ -78,6 +78,18 @@ RSpec.describe PostSlack::CreateSerializer, type: :serializer do
       '- <http://www.example.com/posts/sluggishslug-entitled-title|entitled title> #hacking'
 
       expect(serialized).to eql(expected_text)
+    end
+
+    it 'escapes quotes' do
+      developer = FactoryGirl.build(:developer, username: 'tpope')
+      post = FactoryGirl.create(:post, title: 'Let me prepare you a "quote"')
+
+      serializer = PostSlack::CreateSerializer.new(post)
+      serialized = JSON.parse(serializer.to_json)['text']
+
+      expected_text = 'Let me prepare you a "quote"'
+
+      expect(serialized).to include(expected_text)
     end
   end
 end

--- a/spec/serializers/post_slack/likes_threshold_serializer_spec.rb
+++ b/spec/serializers/post_slack/likes_threshold_serializer_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe PostSlack::LikesThresholdSerializer, type: :serializer do
+
+  def serialize_post(post)
+    serializer = PostSlack::LikesThresholdSerializer.new(post)
+    JSON.parse(serializer.to_json)['text']
+  end
+
   context 'a generic example' do
     it 'is serialized correctly' do
       developer = FactoryGirl.build(:developer,
@@ -13,9 +19,7 @@ RSpec.describe PostSlack::LikesThresholdSerializer, type: :serializer do
                         likes: 10
                        )
 
-      serializer = PostSlack::LikesThresholdSerializer.new(post)
-      serialized = JSON.parse(serializer.to_json)['text']
-
+      serialized = serialize_post(post)
       result = "tpope's post has 10 likes! 🎉 - <http://www.example.com/"\
       "posts/sluggishslug-entitled-title|entitled title>"
 
@@ -34,9 +38,7 @@ RSpec.describe PostSlack::LikesThresholdSerializer, type: :serializer do
                         likes: 10
                        )
 
-      serializer = PostSlack::LikesThresholdSerializer.new(post)
-      serialized = JSON.parse(serializer.to_json)['text']
-
+      serialized = serialize_post(post)
       result = "Tim Pope's post has 10 likes! 🎉 - <http://www.example.com/"\
       "posts/sluggishslug-entitled-title|entitled title>"
 
@@ -55,9 +57,7 @@ RSpec.describe PostSlack::LikesThresholdSerializer, type: :serializer do
                         likes: 10
                        )
 
-      serializer = PostSlack::LikesThresholdSerializer.new(post)
-      serialized = JSON.parse(serializer.to_json)['text']
-
+      serialized = serialize_post(post)
       expected_text = "tpope's post has 10 likes! 🎉 - <http://www.example.com/"\
       "posts/sluggishslug-the-picture-div-elements-are-here-to-stay|The `&lt;picture&gt;` "\
       "&amp; `&lt;div&gt;` elements are here to stay!>"
@@ -69,9 +69,7 @@ RSpec.describe PostSlack::LikesThresholdSerializer, type: :serializer do
       developer = FactoryGirl.build(:developer, username: 'tpope')
       post = FactoryGirl.create(:post, title: 'Let me prepare you a "quote"')
 
-      serializer = PostSlack::LikesThresholdSerializer.new(post)
-      serialized = JSON.parse(serializer.to_json)['text']
-
+      serialized = serialize_post(post)
       expected_text = 'Let me prepare you a "quote"'
 
       expect(serialized).to include(expected_text)

--- a/spec/serializers/post_slack/likes_threshold_serializer_spec.rb
+++ b/spec/serializers/post_slack/likes_threshold_serializer_spec.rb
@@ -64,5 +64,17 @@ RSpec.describe PostSlack::LikesThresholdSerializer, type: :serializer do
 
       expect(serialized).to eql(expected_text)
     end
+
+    it 'is serialized with escaped quotes' do
+      developer = FactoryGirl.build(:developer, username: 'tpope')
+      post = FactoryGirl.create(:post, title: 'Let me prepare you a "quote"')
+
+      serializer = PostSlack::LikesThresholdSerializer.new(post)
+      serialized = JSON.parse(serializer.to_json)['text']
+
+      expected_text = 'Let me prepare you a "quote"'
+
+      expect(serialized).to include(expected_text)
+    end
   end
 end


### PR DESCRIPTION
Previous implementation was too broad; Slack requires only three
symbols to be escaped.

https://api.slack.com/docs/formatting#how_to_escape_characters

Issue #47