### PR TITLE
Select published_at when grouping posts by date

### DIFF
--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -54,7 +54,7 @@ class StatisticsController < ApplicationController
   def find_posts_per_day
     sql = <<-SQL
       with posts as (
-           select date((created_at at time zone 'UTC' at time zone 'America/New_York')::timestamptz) as post_date
+           select date((published_at at time zone 'UTC' at time zone 'America/New_York')::timestamptz) as post_date
               from posts
               where published_at is not null
       )


### PR DESCRIPTION
- [x] select published_at when grouping posts by date

## current behavior:

I created a draft on June 6th and finally published June 7th, and the statistics were considering the `created_at` field.

<img width="145" alt="screen shot 2016-06-07 at 8 40 58 am" src="https://cloud.githubusercontent.com/assets/1071893/15857868/9ad8c810-2c8b-11e6-952e-1931d413b2a4.png">

- [TIL statistics page](https://til.hashrocket.com/statistics)