### PR TITLE
Open links on new tabs

### DIFF
--- a/lib/red_carpet_code_highlighter.rb
+++ b/lib/red_carpet_code_highlighter.rb
@@ -4,4 +4,8 @@ require 'rouge/plugins/redcarpet'
 
 class RedCarpetCodeHighlighter < Redcarpet::Render::HTML
   include Rouge::Plugins::Redcarpet
+
+  def initialize(extensions = {})
+    super extensions.merge(link_attributes: { target: "_blank" })
+  end
 end

--- a/spec/helpers/markdown_helper_spec.rb
+++ b/spec/helpers/markdown_helper_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe MarkdownHelper, type: :helper do
         let(:text) { '[My link](http://link.com)' }
 
         it 'parses links' do
-          is_expected.to include('<a href="http://link.com">My link</a>')
+          is_expected.to include('<a href="http://link.com" target="_blank">My link</a>')
         end
       end
     end

--- a/spec/helpers/markdown_helper_spec.rb
+++ b/spec/helpers/markdown_helper_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe MarkdownHelper, type: :helper do
+  describe '#markdown' do
+    before { include described_class }
+
+    describe '#render' do
+      subject { markdown.render(text) }
+
+      context 'with links' do
+        let(:text) { '[My link](http://link.com)' }
+
+        it 'parses links' do
+          is_expected.to include('<a href="http://link.com">My link</a>')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- [x] open links on new tabs with `target=_blank`
- [x] test markdown rendering for links

<img width="361" alt="screen shot 2016-06-13 at 10 31 11 am" src="https://cloud.githubusercontent.com/assets/1071893/16011137/2ed615de-3152-11e6-998a-ed13f63cf15b.png">
<img width="537" alt="screen shot 2016-06-13 at 10 31 16 am" src="https://cloud.githubusercontent.com/assets/1071893/16011138/2ed7926a-3152-11e6-92cd-103adb0acedf.png">
