### PR TITLE
Fix twitter card - validation failure

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -16,7 +16,7 @@
     %meta(name="twitter:creator" content="@hashrockettil")
     %meta(name="twitter:title" content="Today I Learned: a Hashrocket Project")
     %meta(name="twitter:description" content="TIL is an open-source project by Hashrocket that exists to catalogue the sharing & accumulation of knowledge as it happens day-to-day. Posts have a 200-word limit, and posting is open to any Rocketeer as well as select friends of the team. We hope you enjoy learning along with us.")
-    %meta(name="twitter:image" content="//til.hashrocket.com/assets/til_twittercard.png")
+    %meta(name="twitter:image" content="https://til.hashrocket.com/assets/til_twittercard.png")
   %body
     - if developer_signed_in?
       %nav.admin_panel


### PR DESCRIPTION
- [x] fix `summary_large_image not found` was preventing card to be rendered

<img width="1007" alt="screen shot 2016-06-22 at 1 22 32 pm" src="https://cloud.githubusercontent.com/assets/1071893/16276588/03d264be-387d-11e6-904b-41e336bc2a1c.png">
<img width="992" alt="screen shot 2016-06-22 at 1 45 25 pm" src="https://cloud.githubusercontent.com/assets/1071893/16277124/9a61f1fe-387f-11e6-87ab-53e57eebf1fe.png">

# references:

- [twitter card validator](https://cards-dev.twitter.com/validator)
- [refreshing twitter cache](https://dev.twitter.com/cards/troubleshooting#refreshing)
