### PR TITLE
Improve code snippet highlight for diff

### DIFF
--- a/app/assets/stylesheets/vividchalk.scss
+++ b/app/assets/stylesheets/vividchalk.scss
@@ -68,3 +68,7 @@
 .highlight .vg { color: #FFCC00; } /* Name.Variable.Global */
 .highlight .vi { color: #FFCC00; } /* Name.Variable.Instance */
 .highlight .il { color: #EEEEEE; } /* Literal.Number.Integer.Long */
+
+.highlight.diff .gh { color: #FFFF00; }
+.highlight.diff .gd { color: #FF0000; background-color: #333333 }
+.highlight.diff .gi { color: #00FF00; background-color: #333333 }


### PR DESCRIPTION
- [x] use other colors for `diff` code highlight

## after

<img width="472" alt="screen shot 2016-06-30 at 1 56 53 pm" src="https://cloud.githubusercontent.com/assets/1071893/16498631/b10e5694-3eca-11e6-8958-dbaf7bc3ae25.png">

## before

<img width="467" alt="screen shot 2016-06-30 at 1 57 02 pm" src="https://cloud.githubusercontent.com/assets/1071893/16498636/b5f41676-3eca-11e6-898a-8092db38d05d.png">
