### PR TITLE
Tweak diff highlight colors to be a little less harsh

### DIFF
--- a/app/assets/stylesheets/vividchalk.scss
+++ b/app/assets/stylesheets/vividchalk.scss
@@ -69,6 +69,6 @@
 .highlight .vi { color: #FFCC00; } /* Name.Variable.Instance */
 .highlight .il { color: #EEEEEE; } /* Literal.Number.Integer.Long */
 
-.highlight.diff .gh { color: #FFFF00; }
-.highlight.diff .gd { color: #FF0000; background-color: #333333 }
-.highlight.diff .gi { color: #00FF00; background-color: #333333 }
+.highlight.diff .gh { color: #f1f159; }
+.highlight.diff .gd { color: #fc4e2b; background-color: #333333 }
+.highlight.diff .gi { color: #3ce670; background-color: #333333 }


### PR DESCRIPTION
# after

<img width="445" alt="screen shot 2016-06-30 at 3 33 06 pm" src="https://cloud.githubusercontent.com/assets/1071893/16501567/f98f90a6-3ed7-11e6-9671-7b223a28de0c.png">

# before

<img width="472" alt="screen shot 2016-06-30 at 1 56 53 pm" src="https://cloud.githubusercontent.com/assets/1071893/16501575/04b5f75e-3ed8-11e6-9a17-f40646060154.png">
