### PR TITLE
Add custom sanitizer to remove script tags

### DIFF
--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,5 +1,6 @@
 require 'red_carpet_code_highlighter'
 require 'tilt/redcarpet'
+require 'post_scrubber'
 
 module MarkdownHelper
   def markdown
@@ -17,6 +18,6 @@ module MarkdownHelper
   end
 
   def markdown_render(md)
-    raw markdown.render md
+    sanitize markdown.render(md), scrubber: PostScrubber.new
   end
 end

--- a/app/views/posts/show.md.erb
+++ b/app/views/posts/show.md.erb
@@ -1,6 +1,6 @@
 <%= sanitize @post.title %>
 
-<%= sanitize @post.body %>
+<%= raw @post.body %>
 
 <%= @post.developer_username %>
 <%= @post.display_date.strftime("%B %-e, %Y") %>

--- a/features/step_definitions/post_steps.rb
+++ b/features/step_definitions/post_steps.rb
@@ -412,6 +412,11 @@ Then 'I see the sanitized title' do
   expect(page).to have_title "It's Friday & Stuff"
 end
 
+Then 'I see the escaped script' do
+  expect(page).to have_content "alert('XSS')"
+  expect(page).not_to have_selector :css, 'script', visible: false, text: "alert('XSS')"
+end
+
 Then 'I see the show page for that edited post' do
   within '.post' do
     expect(page).to have_content 'I changed the header'

--- a/features/visitor_views_post.feature
+++ b/features/visitor_views_post.feature
@@ -107,6 +107,12 @@ Feature: Visitor views post
     Then I see "Raw text content"
     And I should get a response with content-type "text/markdown; charset=utf-8"
 
+  Scenario: Visitor sees escaped HTML
+    Given I am a visitor
+    And a post exists with a body "<script>alert('XSS')</script>"
+    When I visit the show page for that post
+    Then I see the escaped script
+
   @javascript
   Scenario: Visitor sees likes
     Given I am a visitor

--- a/lib/post_scrubber.rb
+++ b/lib/post_scrubber.rb
@@ -1,0 +1,5 @@
+class PostScrubber < Rails::Html::PermitScrubber
+  def allowed_node?(node)
+    !%w(script).include?(node.name)
+  end
+end


### PR DESCRIPTION
I added a "PostScrubber". Currently the method `raw` is being used, which permits everything. The `PostScrubber` uses `Rails::Html::PermitScrubber` and says that `script` nodes are not permitted. So the change effectively goes from "permit everything" to "permit everything except scripts".

This addresses users being able to execute their own javascript through `script` tags, but I don't believe it prevents the use of javascript in html attributes.