### PR TITLE
Add a random post page

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -95,8 +95,8 @@ class PostsController < ApplicationController
 
   def random
     path =
-      if post = Post.published.sample
-        post_path(post)
+      if random = Post.random.first
+        post_path(random)
       else
         root_path
       end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,7 @@
 class PostsController < ApplicationController
-  before_action :set_post, only: [:show, :edit, :update]
-  before_action :require_developer, except: [:index, :show, :like, :unlike]
-  before_action :authorize_developer, only: [:edit, :update]
+  before_action :set_post, only: %i[edit show update]
+  before_action :require_developer, except: %i[index like random show unlike]
+  before_action :authorize_developer, only: %i[edit update]
 
   def preview
     render layout: false
@@ -91,6 +91,17 @@ class PostsController < ApplicationController
     end
 
     render :index
+  end
+
+  def random
+    path =
+      if post = Post.published.sample
+        post_path(post)
+      else
+        root_path
+      end
+
+    redirect_to path
   end
 
   private

--- a/app/helpers/post_helper.rb
+++ b/app/helpers/post_helper.rb
@@ -11,6 +11,10 @@ module PostHelper
     post == Post.published_and_ordered.last
   end
 
+  def published_posts?
+    Post.published.any?
+  end
+
   def previous_post(post)
     posts = Post.published_and_ordered
     posts[posts.index(post) + 1]

--- a/app/helpers/post_helper.rb
+++ b/app/helpers/post_helper.rb
@@ -1,6 +1,6 @@
 module PostHelper
-  def multiple_posts?
-    Post.count > 1
+  def multiple_published_posts?
+    Post.published.count > 1
   end
 
   def newest_post?(post)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -20,6 +20,7 @@ class Post < ActiveRecord::Base
   scope :drafts, -> { where('published_at is null') }
   scope :published_and_ordered, -> { published.order(published_at: :desc) }
   scope :published_and_untweeted, -> { published.where('tweeted is false') }
+  scope :random, -> { published.order('random()').limit(1) }
 
   MAX_TITLE_CHARS = 50
   MAX_WORDS = 200

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -12,4 +12,7 @@
 
 %nav.pagination
   = link_to_previous_page @posts, "newer TILs".html_safe, class: "pagination_newer"
+  - if published_posts?
+    = link_to random_path do
+      random TIL
   = link_to_next_page @posts, "older TILs".html_safe, class: "pagination_older"

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -3,13 +3,13 @@
 - content_for :post_nav do
   - if @post.published?
     %nav.pagination
-      - unless oldest_post? @post
+      - if multiple_published_posts? && !oldest_post?(@post)
         = link_to previous_post(@post), class: "pagination_newer" do
           previous TIL
       - if published_posts?
         = link_to random_path do
           random TIL
-      - unless newest_post? @post
+      - if multiple_published_posts? && !newest_post?(@post)
         = link_to next_post(@post), class: "pagination_older" do
           next TIL
 

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -1,11 +1,14 @@
 - content_for :page_title, @post.title
 
 - content_for :post_nav do
-  - if @post.published? && multiple_posts?
+  - if @post.published?
     %nav.pagination
       - unless oldest_post? @post
         = link_to previous_post(@post), class: "pagination_newer" do
           previous TIL
+      - if published_posts?
+        = link_to random_path do
+          random TIL
       - unless newest_post? @post
         = link_to next_post(@post), class: "pagination_older" do
           next TIL

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   get '/auth/google_oauth2', as: 'google_oauth2'
   get '/auth/google_oauth2/callback', to: 'sessions#create'
 
-  get 'account/signout', to: 'sessions#destroy'
+  get '/account/signout', to: 'sessions#destroy'
   get '/posts_drafts', to: 'posts#drafts', as: :drafts
   get '/random', to: 'posts#random', as: :random
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
 
   get 'account/signout', to: 'sessions#destroy'
   get '/posts_drafts', to: 'posts#drafts', as: :drafts
+  get '/random', to: 'posts#random', as: :random
 
   resources :channels, path: '/', only: :show
   post '/post_preview', to: 'posts#preview'

--- a/features/step_definitions/general_steps.rb
+++ b/features/step_definitions/general_steps.rb
@@ -165,3 +165,7 @@ end
 And "I don't see a search header" do
   expect(page).to_not have_selector ".page_head"
 end
+
+And 'no posts exist' do
+  # noop
+end

--- a/features/step_definitions/post_steps.rb
+++ b/features/step_definitions/post_steps.rb
@@ -625,3 +625,11 @@ Then 'I see the author\'s Twitter link' do
     expect(page).to have_link '@sqlfan', href: 'https://twitter.com/sqlfan'
   end
 end
+
+When 'I visit the random page' do
+  visit random_path
+end
+
+Then 'I see the random post' do
+  expect(current_path).to eq post_path @post
+end

--- a/features/step_definitions/post_steps.rb
+++ b/features/step_definitions/post_steps.rb
@@ -215,12 +215,6 @@ When 'I see only a previous TIL link' do
   end
 end
 
-When 'I click the previous TIL link' do
-  within '.pagination' do
-    click_on 'previous TIL'
-  end
-end
-
 Then 'I see the second most recent post' do
   expect(current_path).to eq(post_path(@older_post))
 end
@@ -240,12 +234,6 @@ When 'I see only a next TIL link' do
   within '.pagination' do
     expect(page).to have_link 'next TIL'
     expect(page).to_not have_link 'previous TIL'
-  end
-end
-
-When 'I click the next TIL link' do
-  within '.pagination' do
-    click_on 'next TIL'
   end
 end
 

--- a/features/visitor_views_post.feature
+++ b/features/visitor_views_post.feature
@@ -45,13 +45,13 @@ Feature: Visitor views post
     And three posts exist
     When I go to the most recent post
     Then I see only a previous TIL link
-    When I click the previous TIL link
+    When I click "previous TIL"
     Then I see the second most recent post
     And I see a next TIL link and a previous TIL link
-    When I click the previous TIL link
+    When I click "previous TIL"
     Then I see the least recent post
     And I see only a next TIL link
-    When I click the next TIL link
+    When I click "next TIL"
     Then I see the second most recent post
 
   Scenario: Visitor clicks on 'previous' arrow with a draft post
@@ -59,7 +59,7 @@ Feature: Visitor views post
     And three posts exist, one a draft
     When I go to the most recent post
     Then I see only a previous TIL link
-    When I click the previous TIL link
+    When I click "previous TIL"
     Then I see the least recent post
     And I see only a next TIL link
 
@@ -68,13 +68,13 @@ Feature: Visitor views post
     And three posts exist, with publication dates in a different order than creation dates
     When I go to the most recent post
     Then I see only a previous TIL link
-    When I click the previous TIL link
+    When I click "previous TIL"
     Then I see the second most recent post
     And I see a next TIL link and a previous TIL link
-    When I click the previous TIL link
+    When I click "previous TIL"
     Then I see the least recent post
     And I see only a next TIL link
-    When I click the next TIL link
+    When I click "next TIL"
     Then I see the second most recent post
 
   Scenario: Visitor mangles url
@@ -120,6 +120,14 @@ Feature: Visitor views post
     Given I am a visitor
     And a post exists
     And I visit the random page
+    Then I see the random post
+
+  Scenario: Visitor views a randomly selected post via link
+    Given I am a visitor
+    And a post exists
+    And I visit the random page
+    Then I see the random post
+    When I click "random TIL"
     Then I see the random post
 
   Scenario: Visitor sees a homepage when there are no posts to randomly select from

--- a/features/visitor_views_post.feature
+++ b/features/visitor_views_post.feature
@@ -115,3 +115,15 @@ Feature: Visitor views post
     When I click on the title of the post
     Then I see the show page for that post
     And I see the likes count equals 10
+
+  Scenario: Visitor views a randomly selected post
+    Given I am a visitor
+    And a post exists
+    And I visit the random page
+    Then I see the random post
+
+  Scenario: Visitor sees a homepage when there are no posts to randomly select from
+    Given I am a visitor
+    And no posts exist
+    When I visit the random page
+    Then I am on the homepage

--- a/features/visitor_views_posts.feature
+++ b/features/visitor_views_posts.feature
@@ -60,3 +60,10 @@ Feature: Visitor views posts
     Then I should see 50 posts
     And I should not see a "newer TILs" button
     And I should not see a "older TILs" button
+
+  Scenario: Visitor views a randomly selected post via link
+    Given I am a visitor
+    And a post exists
+    When I visit the homepage
+    And I click "random TIL"
+    Then I see the random post


### PR DESCRIPTION
The purpose of this page is to allow people to see a random post for fun and profit. We have about 850 posts on Hashrocket's TIL now. I think this would be a fun journey through the back catalogue.