### PR TITLE
Don't sanitize raw markdown

### DIFF
--- a/app/views/posts/show.md.erb
+++ b/app/views/posts/show.md.erb
@@ -1,6 +1,6 @@
-<%= sanitize @post.title %>
+<%=raw @post.title %>
 
-<%= sanitize @post.body %>
+<%=raw @post.body %>
 
 <%= @post.developer_username %>
 <%= @post.display_date.strftime("%B %-e, %Y") %>

--- a/features/visitor_views_post.feature
+++ b/features/visitor_views_post.feature
@@ -87,9 +87,9 @@ Feature: Visitor views post
 
   Scenario: Visitor views raw text of post via path
     Given I am a visitor
-    And a post exists with a body "Raw text content"
+    And a post exists with a body "Raw text content with code `{:empty => nil}`"
     And I visit the post text page
-    Then I see "Raw text content"
+    Then I see "Raw text content with code `{:empty => nil}`"
     And I should get a response with content-type "text/markdown; charset=utf-8"
 
   Scenario: Visitor views raw text of post via button


### PR DESCRIPTION
  Because the raw format is being delivered as "plain text"
  there is no need to sanitize it.