### PR TITLE
Only admins can see all drafts

### DIFF
--- a/features/developer_views_drafts.feature
+++ b/features/developer_views_drafts.feature
@@ -1,0 +1,15 @@
+Feature: Developer views drafts
+
+  Scenario: Admin views drafts
+    Given I am a signed in developer
+    And I am an admin
+    And 2 drafts exist by another developer
+    When I click "Drafts"
+    Then I see 2 posts
+
+  Scenario: Non-admin views drafts
+    Given I am a signed in developer
+    And I have a draft post
+    And 5 drafts exist by another developer
+    When I click "Drafts"
+    Then I see 1 post

--- a/features/step_definitions/developer_steps.rb
+++ b/features/step_definitions/developer_steps.rb
@@ -45,6 +45,10 @@ And 'I have a post' do
   @post = FactoryGirl.create(:post, developer: @developer)
 end
 
+And 'I have a draft post' do
+  FactoryGirl.create(:post, :draft, developer: @developer)
+end
+
 And 'I have a post with markdown' do
   FactoryGirl.create(:post, developer: @developer, body: '*emphasis*')
 end

--- a/features/step_definitions/post_steps.rb
+++ b/features/step_definitions/post_steps.rb
@@ -48,6 +48,10 @@ Given 'a post exists by another developer' do
   @others_post = FactoryGirl.create(:post)
 end
 
+Given(/^(\d+) drafts* exists* by another developer$/) do |num|
+  FactoryGirl.create_list(:post, num.to_i, :draft)
+end
+
 When 'I visit the edit page for that post' do
   visit edit_post_path @others_post
 end
@@ -622,4 +626,8 @@ Then 'I see the author\'s Twitter link' do
   within 'header.page_head' do
     expect(page).to have_link '@sqlfan', href: 'https://twitter.com/sqlfan'
   end
+end
+
+Then(/^I see (\d+) posts*$/) do |num|
+  expect(page).to have_selector 'article', count: num.to_i
 end

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -168,17 +168,22 @@ RAW
   end
 
   describe '#drafts' do
+
     before do
       controller.sign_in developer
     end
 
-    context 'when I am a non-admin developer' do
-      let(:developer) { FactoryGirl.create :developer }
+    context 'when I am a non-admin' do
 
-      it 'lists only my own drafts' do
-        FactoryGirl.create_list :post, 3, :draft, developer: developer
+      let(:developer) { FactoryGirl.create :developer }
+      let(:rando) { FactoryGirl.create :developer }
+
+      it 'lists only my drafts' do
         FactoryGirl.create_list :post, 3, developer: developer
-        FactoryGirl.create_list :post, 3, :draft
+        FactoryGirl.create_list :post, 3, :draft, developer: developer
+
+        FactoryGirl.create_list :post, 3, developer: rando
+        FactoryGirl.create_list :post, 3, :draft, developer: rando
         get :drafts
 
         expect(assigns(:posts).length).to eq(3)
@@ -186,11 +191,16 @@ RAW
     end
 
     context 'when I am an admin developer' do
+
       let(:developer) { FactoryGirl.create :developer, admin: true }
+      let(:rando) { FactoryGirl.create :developer }
 
       it 'lists all drafts' do
+        FactoryGirl.create_list :post, 3, developer: developer
         FactoryGirl.create_list :post, 3, :draft, developer: developer
-        FactoryGirl.create_list :post, 3, :draft
+
+        FactoryGirl.create_list :post, 3, developer: rando
+        FactoryGirl.create_list :post, 3, :draft, developer: rando
         get :drafts
 
         expect(assigns(:posts).length).to eq(6)


### PR DESCRIPTION
This was an MVP feature that deserves better tests. Only admins should be able to see all drafts. Non-admins should only be able to see their own drafts.