### PR TITLE
Prevent single dashes from being stripped out

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -105,7 +105,7 @@ class Post < ActiveRecord::Base
   end
 
   def slugified_title
-    title.downcase.strip.gsub(/[^A-Za-z0-9\s]/, '').gsub(/(\s|-)+/, '-')
+    title.downcase.strip.gsub(/[^A-Za-z0-9\s-]/, '').gsub(/(\s|-)+/, '-')
   end
 
   def notify_slack(event)

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -58,6 +58,11 @@ describe Post do
     expect(post.send(:slugified_title)).to eq valid_title
   end
 
+  it 'should use title dashes in slug' do
+    post.title = 'Today I learned about clojure-like syntax feature'
+    expect(post.send(:slugified_title)).to eq 'today-i-learned-about-clojure-like-syntax-feature'
+  end
+
   it 'should remove whitespace from slug' do
     post.title = '  Today I             learned about clojure   '
     expect(post.send(:slugified_title)).to eq valid_title


### PR DESCRIPTION
A recent example was a post titled:

`Ruby-Like `split` in Elixir`

being slugified to:

`rubylike-split-in-elixir`

The dash between `ruby` and `like` was being erroneously stripped out.
This commit fixes that by not stripping out any dashes in the first
`gsub` of `#slugified_title`.