### PR TITLE
Add a rake task to tweet a random published post

### DIFF
--- a/lib/tasks/twitter.rake
+++ b/lib/tasks/twitter.rake
@@ -1,0 +1,9 @@
+namespace :twitter do
+  desc 'Tweets a random published post'
+  task tweet_random_post: :environment do
+    random_post = Post.published.sample
+    puts "Tweeting random post: #{post.title}... "
+    SocialMessaging::TwitterStatus.new(post).post_to_twitter
+    print 'completed.'
+  end
+end


### PR DESCRIPTION
This is part of prep the exhaustion of the 'published_and_untweeted' collection of early-adopter posts coming up in two months. Random twitter posts are a fun part of having a large back catalogue, and I'd like to keep it going.

Can be integrated with a cron job or Heroku scheduler.