### PR TITLE
Remove slug whitespace left after stripping Emojis

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -105,7 +105,7 @@ class Post < ActiveRecord::Base
   end
 
   def slugified_title
-    title.downcase.strip.gsub(/[^A-Za-z0-9\s-]/, '').gsub(/(\s|-)+/, '-')
+    title.downcase.gsub(/[^A-Za-z0-9\s-]/, '').strip.gsub(/(\s|-)+/, '-')
   end
 
   def notify_slack(event)

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -48,29 +48,36 @@ describe Post do
     end
   end
 
-  it 'should create a slug with dashes' do
-    post.title = 'Today I learned about clojure'
-    expect(post.send(:slugified_title)).to eq valid_title
-  end
+  describe '#slugified_title' do
+    it 'should create a slug with dashes' do
+      post.title = 'Today I learned about clojure'
+      expect(post.send(:slugified_title)).to eq valid_title
+    end
 
-  it 'should create a slug without multiple dashes' do
-    post.title = 'Today I learned --- about clojure'
-    expect(post.send(:slugified_title)).to eq valid_title
-  end
+    it 'should create a slug without multiple dashes' do
+      post.title = 'Today I learned --- about clojure'
+      expect(post.send(:slugified_title)).to eq valid_title
+    end
 
-  it 'should use title dashes in slug' do
-    post.title = 'Today I learned about clojure-like syntax feature'
-    expect(post.send(:slugified_title)).to eq 'today-i-learned-about-clojure-like-syntax-feature'
-  end
+    it 'should use title dashes in slug' do
+      post.title = 'Today I learned about clojure-like syntax feature'
+      expect(post.send(:slugified_title)).to eq 'today-i-learned-about-clojure-like-syntax-feature'
+    end
 
-  it 'should remove whitespace from slug' do
-    post.title = '  Today I             learned about clojure   '
-    expect(post.send(:slugified_title)).to eq valid_title
-  end
+    it 'should remove whitespace from slug' do
+      post.title = '  Today I             learned about clojure   '
+      expect(post.send(:slugified_title)).to eq valid_title
+    end
 
-  it 'should not allow punctuation in slug' do
-    post.title = 'Today I! learned? & $ % about #clojure'
-    expect(post.send(:slugified_title)).to eq valid_title
+    it 'should not allow punctuation in slug' do
+      post.title = 'Today I! learned? & $ % about #clojure'
+      expect(post.send(:slugified_title)).to eq valid_title
+    end
+
+    it 'should ignore and strip emojis' do
+      post.title = 'Today I learned about clojure 😀'
+      expect(post.send(:slugified_title)).to eq valid_title
+    end
   end
 
   describe '#body_size' do


### PR DESCRIPTION
Close #102

Stripping whitespace after removing all non-essential characters catches
trailing spaces.