### PR TITLE
Redirect bots

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,9 @@ Rails.application.routes.draw do
   get 'account/signout', to: 'sessions#destroy'
   get '/posts_drafts', to: 'posts#drafts', as: :drafts
 
+  # Bot redirects
+  get '/wp-login.php' => redirect('/')
+
   resources :channels, path: '/', only: :show
   post '/post_preview', to: 'posts#preview'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,10 @@ Rails.application.routes.draw do
 
   root to: 'posts#index'
 
+  # Bot redirects
+  get 'wp-login.php' => redirect('/')
+  get 'authors/wp-login.php' => redirect('/')
+
   resource :profile, controller: 'developers', only: %i(update edit)
   resources :developers, path: '/authors', only: 'show'
 
@@ -15,9 +19,6 @@ Rails.application.routes.draw do
 
   get 'account/signout', to: 'sessions#destroy'
   get '/posts_drafts', to: 'posts#drafts', as: :drafts
-
-  # Bot redirects
-  get '/wp-login.php' => redirect('/')
 
   resources :channels, path: '/', only: :show
   post '/post_preview', to: 'posts#preview'

--- a/features/step_definitions/general_steps.rb
+++ b/features/step_definitions/general_steps.rb
@@ -165,3 +165,7 @@ end
 And "I don't see a search header" do
   expect(page).to_not have_selector ".page_head"
 end
+
+Given(/^I try to visit "([^"]*)"$/) do |url|
+  visit url
+end

--- a/features/visitor_is_a_bot.feature
+++ b/features/visitor_is_a_bot.feature
@@ -1,6 +1,11 @@
 Feature: Visitor is a bot
 
-  Scenario: And tries to visit Wordpress login
+  Scenario: And tries to visit Wordpress login via channels
     Given I am a visitor
     And I try to visit "/wp-login.php"
+    Then I am on the homepage
+
+  Scenario: And tries to visit Wordpress login via developers
+    Given I am a visitor
+    And I try to visit "authors/wp-login.php"
     Then I am on the homepage

--- a/features/visitor_is_a_bot.feature
+++ b/features/visitor_is_a_bot.feature
@@ -1,0 +1,6 @@
+Feature: Visitor is a bot
+
+  Scenario: And tries to visit Wordpress login
+    Given I am a visitor
+    And I try to visit "/wp-login.php"
+    Then I am on the homepage


### PR DESCRIPTION
The `/wp-login.php` and `/authors/wp-login.php` URLs get hammered by bots, raising errors that get caught by Airbrake (~600 in a couple of weeks).

I hope this pattern can be followed for other bot-favorite routes.