### PR TITLE
Add canonical link for each post

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -17,6 +17,9 @@
     %meta(name="twitter:title" content="Today I Learned: a Hashrocket Project")
     %meta(name="twitter:description" content="TIL is an open-source project by Hashrocket that exists to catalogue the sharing & accumulation of knowledge as it happens day-to-day. Posts have a 200-word limit, and posting is open to any Rocketeer as well as select friends of the team. We hope you enjoy learning along with us.")
     %meta(name="twitter:image" content="https://til.hashrocket.com/assets/til_twittercard.png")
+
+    = yield :canonical
+
   %body
     - if developer_signed_in?
       %nav.admin_panel

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -1,5 +1,8 @@
 - content_for :page_title, @post.title
 
+- content_for :canonical do
+  %link{rel: 'canonical', href: post_url(@post)}
+
 - content_for :post_nav do
   - if @post.published? && multiple_posts?
     %nav.pagination

--- a/features/step_definitions/post_steps.rb
+++ b/features/step_definitions/post_steps.rb
@@ -414,6 +414,10 @@ Then 'I see the sanitized link' do
   expect(find_link('Click here')[:onclick]).not_to eq 'javascript:alert("XSS")'
 end
 
+Then 'I see the canonical link for this post' do
+  expect(page.find('head link[rel=canonical]', visible: false)['href']).to include(@post.slug)
+end
+
 Then 'I see the show page for that edited post' do
   within '.post' do
     expect(page).to have_content 'I changed the header'

--- a/features/visitor_views_post.feature
+++ b/features/visitor_views_post.feature
@@ -27,6 +27,12 @@ Feature: Visitor views post
     When I visit the show page for that post
     Then I do not see the more info partial on the show page
 
+  Scenario: Robot Visitor sees canonical link
+    Given I am a visitor
+    And a post exists with a punctuated title
+    When I visit the show page for that post
+    Then I see the canonical link for this post
+
   Scenario: Visitor clicks on post date
     Given I am a visitor
     And a post exists


### PR DESCRIPTION
When til content is found in search engines the search engines have been linking to the "channel" page or the "author" page instead of the page that is the canonical source for the content, the post page.

This will help users find the right content when they navigate to the site through a search engine query.