### PR TITLE
Auto-refresh page only with an internet connection

### DIFF
--- a/app/assets/javascripts/autorefresh.js
+++ b/app/assets/javascripts/autorefresh.js
@@ -1,13 +1,19 @@
 $(function(){
+  var reloadPage = function() {
+    if(navigator.onLine) {
+      location.reload(true);
+    }
+  };
+
   var autorefresh = function() {
     var timeout;
     var resetRefreshCounter = function(){
         clearTimeout(timeout);
-        timeout = setTimeout(function(){location.reload(true);}, 10 * 60 * 1000);
+        timeout = setTimeout(reloadPage, 10 * 60 * 1000);
     }
     $(document).on('mousemove', resetRefreshCounter);
     resetRefreshCounter();
-  }
+  };
 
   if ($("#home").length) {
     autorefresh();


### PR DESCRIPTION
This makes the page a bit more offline-friendly. For instance, if I had
loaded the page, then got on a plane, after a period of time, the page's
javascript would kill the content when trying to do the auto-refresh.
With this online check, that won't happen.